### PR TITLE
Require at least v0.6 of `guzzlehttp/oauth-subscriber`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,7 @@
         "php": ">=7.3",
         "guzzlehttp/guzzle": "^7.0 || ^8.0",
         "guzzlehttp/guzzle-services": "^1.2",
-        "guzzlehttp/oauth-subscriber": "^0.4"
+        "guzzlehttp/oauth-subscriber": "^0.6"
     },
     "require-dev": {
         "phpunit/phpunit": "^8.5.23 || ^9.0",


### PR DESCRIPTION
This PR adjusts the dependencies in `composer.json` to require _at least_ version `0.6.0` of `guzzlehttp/oauth-subscriber`. Fixes #3.